### PR TITLE
Removes extra arrowhead from non-Firefox

### DIFF
--- a/python/web/asviz/static/js/tab-topocola.js
+++ b/python/web/asviz/static/js/tab-topocola.js
@@ -266,7 +266,6 @@ function update() {
     });
     var markerPath = pathsg.selectAll("path.marker").data(markerLinks)
     markerPath.enter().append("path").attr("class", function(d) {
-        console.log("marker " + d.type);
         return "marker " + d.type;
     }).attr("marker-end", function(d) {
         return "url(#" + d.color + ")";
@@ -465,13 +464,16 @@ function drawPath(res, path, color) {
         return !link.path;
     });
     for (var i = 0; i < path_ids.length - 1; i++) {
-        graphPath.links.push({
-            "color" : color,
-            "path" : true,
-            "source" : graphPath["ids"][path_ids[i]],
-            "target" : graphPath["ids"][path_ids[i + 1]],
-            "type" : "PARENT"
-        });
+        // prevent src == dst links from being formed
+        if (path_ids[i] != path_ids[i + 1]) {
+            graphPath.links.push({
+                "color" : color,
+                "path" : true,
+                "source" : graphPath["ids"][path_ids[i]],
+                "target" : graphPath["ids"][path_ids[i + 1]],
+                "type" : "PARENT"
+            });
+        }
     }
     update();
 }


### PR DESCRIPTION
This pull request was recreated from @mwfarb's refork. All old PR #26 still open to preserve discussion until this PR is closed.
- Removes same interface links from constructed paths.
- Effectually removes extra arrowhead at the 9pm position on ASes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-viz/36)
<!-- Reviewable:end -->
