### PR TITLE
Adds display of core/non-core AS, path type, segments from sciond

### DIFF
--- a/python/as_viewer.py
+++ b/python/as_viewer.py
@@ -26,7 +26,6 @@ import time
 from os.path import dirname as dir
 
 import lib.app.sciond as lib_sciond
-from lib.app.sciond import SCIONBaseError
 from lib.app.sciond import SCIONDConnectionError, SCIONDResponseError
 from lib.crypto.certificate_chain import get_cert_chain_file_path
 from lib.crypto.trc import get_trc_file_path
@@ -36,10 +35,14 @@ from lib.defines import (
     PATH_POLICY_FILE,
     SCIOND_API_SOCKDIR,
 )
+from lib.errors import SCIONBaseError
 from lib.packet.host_addr import HostAddrIPv4
-from lib.packet.opaque_field import HopOpaqueField, InfoOpaqueField
 from lib.packet.scion_addr import ISD_AS
-from lib.types import ServiceType
+from lib.sciond_api.segment_req import SCIONDSegTypeHopReplyEntry
+from lib.types import (
+    PathSegmentType as PST,
+    ServiceType,
+)
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SCION_ROOT = dir(dir(BASE_DIR))
@@ -81,6 +84,8 @@ def init():
                         default=False, help='display source AS configuration')
     parser.add_argument('-pp', action="store_true",
                         default=False, help='display source path policy')
+    parser.add_argument('-s', action="store_true", default=False,
+                        help='display segments summary')
 
     args = parser.parse_args()
     s_isd_as = ISD_AS(args.src_isdas)
@@ -127,7 +132,9 @@ def print_as_viewer_info(addr):
             print_json(get_trc_file_path(conf_dir, s_isd_as._isd, 0))
         if args.crt:  # cert chain
             print_json(get_cert_chain_file_path(conf_dir, s_isd_as, 0))
-    except (SCIONBaseError) as err:
+        if args.s:  # segments
+            print_segments_summary(s_isd_as, connector)
+    except (SCIONBaseError, AttributeError) as err:
         logging.error("%s: %s" % (err.__class__.__name__, err))
 
 
@@ -215,9 +222,9 @@ def print_paths(s_isd_as, d_isd_as, connector):
         logging.info("MTU: %s" % path.p.path.mtu)
         logging.info("IPV4: %s" % HostAddrIPv4(path.p.hostInfo.addrs.ipv4))
         logging.info("Port: %s" % path.p.hostInfo.port)
-        logging.info("Interfaces Len: %s" % len(path.p.path.interfaces))
+        logging.info("Hops: %i" % (len(path.p.path.interfaces) / 2))
         # enumerate path interfaces
-        for interface in reversed(path.p.path.interfaces):
+        for interface in path.p.path.interfaces:
             isd_as = ISD_AS(interface.isdas)
             link = interface.ifID
             logging.info("%s-%s (%s)" %
@@ -226,7 +233,7 @@ def print_paths(s_isd_as, d_isd_as, connector):
         i += 1
 
 
-def print_segments_summary(csegs, dsegs, usegs):
+def print_segments_summary(s_isd_as, connector):
     '''
     Print all up, down, and core segments in summary.
     :param csegs: Array of core segments.
@@ -234,6 +241,12 @@ def print_segments_summary(csegs, dsegs, usegs):
     :param usegs: Array of up segments.
     '''
     logging.info("----------------- SEGMENTS")
+    csegs = lib_sciond.get_segtype_hops(
+        PST.CORE, connector=connector[s_isd_as])
+    usegs = lib_sciond.get_segtype_hops(
+        PST.UP, connector=connector[s_isd_as])
+    dsegs = lib_sciond.get_segtype_hops(
+        PST.DOWN, connector=connector[s_isd_as])
     print_enum_segments(csegs, "CORE")
     print_enum_segments(dsegs, "DOWN")
     print_enum_segments(usegs, "UP")
@@ -247,9 +260,8 @@ def print_enum_segments(segs, type):
     '''
     segidx = 1
     for seg in segs:
-        p = seg.p
-        logging.info("%s\t%s\thops: %s\t\tinterface id: %s" %
-                     (type, segidx, len(p.asms), p.ifID))
+        seg_str = SCIONDSegTypeHopReplyEntry(seg.p).short_desc()
+        logging.info("%s %s\t%s" % (type, segidx, seg_str))
         segidx += 1
 
 
@@ -316,62 +328,6 @@ def get_service_type_name(name):
             return group[type]
     # default
     return name
-
-
-def p_segment(seg, idx, name):
-    '''
-    Print segment detail.
-    :param seg: Segment object.
-    :param idx: Segment index (0-based).
-    :param name: Segment label.
-    '''
-    logging.info("----------------- %s SEGMENT %s" % (name, idx + 1))
-    logging.info("Expiration Time: %s" % seg._min_exp)
-    p = seg.p
-    # InfoOpaqueField
-    logging.info("%s" % InfoOpaqueField(p.info))
-    # PathSegment
-    logging.info("Interface ID: %s" % p.ifID)
-    logging.info("SIBRA Ext Up: %s" % p.exts.sibra.up)
-    asmsidx = 1
-    for asms in p.asms:
-        p_as_marking(asms, asmsidx)
-        asmsidx += 1
-
-
-def p_as_marking(asms, idx):
-    '''
-    Print ASMarking object.
-    :param asms: ASMarking object.
-    :param idx: ASMarking index.
-    '''
-    # ASMarking
-    logging.info("  ----------------- AS Marking Block %s" % idx)
-    logging.info("  AS: %s" % ISD_AS(asms.isdas))
-    logging.info("  TRC: v%s" % asms.trcVer)
-    logging.info("  Cert: v%s" % asms.certVer)
-    logging.info("  Interface ID Size: %s" % asms.ifIDSize)
-    logging.info("  Hashtree Root: %s" % asms.hashTreeRoot.hex())
-    logging.info("  Signature: %s" % asms.sig.hex())
-    logging.info("  AS MTU: %s" % asms.mtu)
-    pcbmsidx = 1
-    for pcbms in asms.pcbms:
-        p_pcb_marking(pcbms, pcbmsidx)
-        pcbmsidx += 1
-
-
-def p_pcb_marking(pcbms, idx):
-    '''
-    Print PCBMarking object.
-    :param pcbms: PCBMarking object.
-    :param idx: PCBMarking index.
-    '''
-    # PCBMarking
-    logging.info("    ----------------- PCB Marking Block %s" % idx)
-    logging.info("    In: %s (%s) mtu = %s" %
-                 (ISD_AS(pcbms.inIA), pcbms.inIF, pcbms.inMTU))
-    logging.info("    Out: %s (%s)" % (ISD_AS(pcbms.outIA), pcbms.outIF))
-    logging.info("    %s" % HopOpaqueField(pcbms.hof))
 
 
 def organize_topo(t):

--- a/python/web/asviz/static/js/tab-topocola.js
+++ b/python/web/asviz/static/js/tab-topocola.js
@@ -50,10 +50,20 @@ var pt_w = 90; // text node rect width
 var pt_h = 35; // text node rect height
 var pt_r = 4; // text node rect corner radius
 var pl_w = 20; // path legend width
+var ph_h = 25; // path title header height
+var ph_m = 5; // path title header margin
+var ph_p = ph_h + ph_m; // path title header padding
 
 var pageBounds;
 var circlesg;
 var linesg;
+
+// Timer
+var expClock;
+var secondMs = 1000;
+var minuteMs = secondMs * 60;
+var hourMs = minuteMs * 60;
+var yearMs = hourMs * 24;
 
 /*
  * Post-rendering method to add labels to paths graph. The position of these
@@ -72,25 +82,25 @@ function topoSetup(msg, width, height) {
 
     // use smallest path to find min links for basis of anchors
     var paths = resPath.if_lists;
-    var min_interfaces = paths[0].length;
+    var min_interfaces = paths[0].interfaces.length;
     for (path in resPath.if_lists) {
-        if (paths[path].length < min_interfaces) {
-            min_interfaces = paths[path].length;
+        if (paths[path].interfaces.length < min_interfaces) {
+            min_interfaces = paths[path].interfaces.length;
         }
     }
     var min_link = (min_interfaces / 2) - 1;
     // min placement from center for smallest topology (s=src, d=dst)
-    var min_sx = (width / 2) - (pt_w / 2);
-    var min_dx = (width / 2) + (pt_w / 2);
-    var min_y = (height / 2) + (pt_h / 2) + p_link_dist;
+    var min_sx = (width - pt_w) / 2;
+    var min_dx = (width + pt_w) / 2;
+    var min_y = ((height + pt_h) / 2) + p_link_dist;
     // max placement from center for largest topology (max bounds)
     var max_sx = (pt_w / 2);
     var max_dx = width - (pt_w / 2);
     var max_y = height - (pt_h / 2);
     // optimal placement to center based on number of links
-    var opt_sx = min_sx - (min_link / 2 * p_link_dist / 2);
-    var opt_dx = min_dx + (min_link / 2 * p_link_dist / 2);
-    var opt_y = min_y + (min_link / 2 * p_link_dist / 2);
+    var opt_sx = min_sx - (min_link * p_link_dist / 2);
+    var opt_dx = min_dx + (min_link * p_link_dist / 2);
+    var opt_y = min_y + (min_link * p_link_dist / 2);
     // choose optimal placement, else do not exceed max bounds
     if (msg.hasOwnProperty("destination") && !destination_added) {
         addFixedLabel("destination", (opt_dx < max_dx ? opt_dx : max_dx),
@@ -159,7 +169,7 @@ function updatePathProperties(prevPath, currPath, color) {
 /*
  * Initializes paths graph, its handlers, and renders it.
  */
-function drawTopology(div_id, original_json_data, width, height) {
+function drawTopology(div_id, original_json_data, segs, width, height) {
 
     if (original_json_data.length == 0) {
         console.error("No data to draw topology!!");
@@ -170,6 +180,11 @@ function drawTopology(div_id, original_json_data, width, height) {
     }
 
     graphPath = convertLinks2Graph(original_json_data);
+
+    // first node in each up and down segment must be core
+    updateGraphWithSegments(graphPath, segs.up_segments.if_lists, false);
+    updateGraphWithSegments(graphPath, segs.down_segments.if_lists, true);
+
     console.log(JSON.stringify(graphPath));
 
     colorPath = d3.scale.category20();
@@ -203,7 +218,7 @@ function drawTopology(div_id, original_json_data, width, height) {
     circlesg = svgPath.append("g");
 
     update();
-    drawLegend(original_json_data);
+    drawLegend();
     topoColor({
         "source" : "none",
         "destination" : "none",
@@ -289,6 +304,10 @@ function update() {
     var markerLinks = graphPath.links.filter(function(link) {
         return link.path;
     });
+
+    // remove previous markers to prevent color bleeding
+    svgPath.selectAll("path.marker").remove();
+
     var markerPath = pathsg.selectAll("path.marker").data(markerLinks)
     markerPath.enter().append("path").attr("class", function(d) {
         return "marker " + d.type;
@@ -306,7 +325,7 @@ function update() {
         return "node";
     }).attr("id", function(d) {
         return "node_" + d.name;
-    }).call(colaPath.drag).attr("transform", transform);
+    }).call(colaPath.drag).attr("transform", nodeTransform);
 
     nodeg.append("rect").attr("width", function(d) {
         return (d.type == "host") ? pt_w : (2 * p_r)
@@ -341,7 +360,7 @@ function update() {
 
         path.attr("d", linkStraight);
         markerPath.attr("d", linkArc);
-        node.attr("transform", transform);
+        node.attr("transform", nodeTransform);
     });
 
     colaPath.start(10, 15, 20)
@@ -351,10 +370,11 @@ function update() {
  * Returns the SVG instructions for rendering a path arc as a straight line.
  */
 function linkStraight(d) {
+    var yh = p_r + ph_p;
     var x1 = Math.max(p_r, Math.min(pageBounds.width - p_r, d.source.x));
-    var y1 = Math.max(p_r, Math.min(pageBounds.height - p_r, d.source.y));
+    var y1 = Math.max(yh, Math.min(pageBounds.height - p_r, d.source.y));
     var x2 = Math.max(p_r, Math.min(pageBounds.width - p_r, d.target.x));
-    var y2 = Math.max(p_r, Math.min(pageBounds.height - p_r, d.target.y));
+    var y2 = Math.max(yh, Math.min(pageBounds.height - p_r, d.target.y));
 
     var dr = 0;
     return "M" + x1 + "," + y1 + "A" + dr + "," + dr + " 0 0,1 " + x2 + ","
@@ -365,10 +385,11 @@ function linkStraight(d) {
  * Returns the SVG instructions for rendering a path arc.
  */
 function linkArc(d) {
+    var yh = p_r + ph_p;
     var x1 = Math.max(p_r, Math.min(pageBounds.width - p_r, d.source.x));
-    var y1 = Math.max(p_r, Math.min(pageBounds.height - p_r, d.source.y));
+    var y1 = Math.max(yh, Math.min(pageBounds.height - p_r, d.source.y));
     var x2 = Math.max(p_r, Math.min(pageBounds.width - p_r, d.target.x));
-    var y2 = Math.max(p_r, Math.min(pageBounds.height - p_r, d.target.y));
+    var y2 = Math.max(yh, Math.min(pageBounds.height - p_r, d.target.y));
 
     var dx = x2 - x1;
     var dy = y2 - y1;
@@ -380,30 +401,22 @@ function linkArc(d) {
 /*
  * Creates the instructions for positioning each node.
  */
-function transform(d) {
+function nodeTransform(d) {
+    var yh = p_r + ph_p;
     var dx = Math.max(p_r, Math.min(pageBounds.width - p_r, d.x));
-    var dy = Math.max(p_r, Math.min(pageBounds.height - p_r, d.y));
+    var dy = Math.max(yh, Math.min(pageBounds.height - p_r, d.y));
     return "translate(" + dx + "," + dy + ")";
 }
 
 /*
  * Build legend labels based only on visible nodes.
  */
-function buildLabels(json_path) {
+function buildLabels() {
     var shown = [];
-    for (var i = 0; i < json_path.length; i++) {
-        var core = json_path[i].ltype == 'CORE'
-        if (!ISDAS.test(json_path[i].a)) {
-            console.error(json_path[i].a + ' is not a valid ISD-AS!')
-        } else if (core) { // only link src can be core
-            var isdA = json_path[i].a.split('-')[0]
-            shown.push(((parseInt(isdA) - 1) * 4) + (core ? 0 : 1))
-        }
-        if (!ISDAS.test(json_path[i].b)) {
-            console.error(json_path[i].b + ' is not a valid ISD-AS!')
-        } else {
-            var isdB = json_path[i].b.split('-')[0]
-            shown.push(((parseInt(isdB) - 1) * 4) + (core ? 0 : 1))
+    for (var n = 0; n < graphPath.nodes.length; n++) {
+        // if type not placeholder, add to shown
+        if (graphPath.nodes[n].type != "placeholder") {
+            shown.push(graphPath.nodes[n].group);
         }
     }
     return shown;
@@ -413,30 +426,26 @@ function buildLabels(json_path) {
  * Renders the paths legend and color key. Labels should not be "shown" in the
  * legend if they are not in the actual topology being displayed.
  */
-function drawLegend(json_path) {
-    var shown = buildLabels(json_path)
+function drawLegend() {
+    var shown = buildLabels();
     var idx = 0;
     var legend = svgPath.selectAll(".legend").data(colorPath.domain()).enter()
-            .append("g").attr("class", "legend").attr("transform",
-            // Use our enumerated idx for labels, not all-color index i
-            function(d, i) {
+            .append("g").attr("class", "legend").attr("transform", function(d) {
+                // Use our enumerated idx for labels, not all-color index i
+                var y = 0;
                 if (shown.includes(d)) {
-                    var render = "translate(0," + idx * (pl_w + 2) + ")";
+                    y = ph_m + (idx * (pl_w + 2));
                     idx++;
-                    return render;
-                } else {
-                    return "translate(0,0)";
                 }
+                return "translate(0," + y + ")";
             });
-    legend.append("rect").attr("x", 0).attr("width", pl_w).attr("height", pl_w)
-            .style("fill", colorPath).style("visibility", function(d) {
-                if (shown.includes(d)) {
-                    return "visible";
-                } else {
-                    return "hidden";
-                }
-            })
-    legend.append("text").attr("x", pl_w + 5).attr("y", pl_w / 2).attr("dy",
+    legend.append("rect").attr("x", ph_m).attr("width", pl_w).attr("height",
+            pl_w).style("fill", colorPath).style("visibility", function(d) {
+        return shown.includes(d) ? "visible" : "hidden";
+    });
+    var x_offset = (ph_m * 2) + pl_w;
+    var y_offset = pl_w / 2;
+    legend.append("text").attr("x", x_offset).attr("y", y_offset).attr("dy",
             ".35em").style("text-anchor", "begin").text(function(d) {
         if (shown.includes(d)) {
             if (d % 2 === 0) {
@@ -501,8 +510,8 @@ function drawPath(res, path, color) {
     for (var p = 0; p < routes.length; p++) {
         var pNum = parseInt(routes[p]);
         // select the target path, and make iteration as amount of how many
-        for (var ifNum = 0; ifNum < res.if_lists[pNum].length; ifNum++) {
-            var ifRes = res.if_lists[pNum][ifNum];
+        for (var ifNum = 0; ifNum < res.if_lists[pNum].interfaces.length; ifNum++) {
+            var ifRes = res.if_lists[pNum].interfaces[ifNum];
             path_ids.push(ifRes.ISD + '-' + ifRes.AS);
         }
     }
@@ -551,4 +560,46 @@ function restorePath() {
         return !link.path;
     });
     update();
+}
+
+/*
+ * Adds title and countdown to path graph.
+ */
+function drawTitle(title, color, expTime) {
+    width = svgPath.attr("width");
+    height = svgPath.attr("height");
+    removeTitle();
+    svgPath.append("text").attr("class", "title").attr("x", width / 2).attr(
+            "y", ph_h).attr("text-anchor", "middle").style("font-size", "18px")
+            .style("text-weight", "bold").style("fill", color).text(title);
+
+    if (expTime) {
+        remain = (expTime * 1000) - Date.now();
+        var days = Math.floor(remain / yearMs);
+        var hours = Math.floor((remain % yearMs) / hourMs);
+        var minutes = Math.floor((remain % hourMs) / minuteMs);
+        var seconds = Math.floor((remain % minuteMs) / secondMs);
+        var clock = [];
+        clock.push(('00' + hours).substr(-2), ('00' + minutes).substr(-2),
+                ('00' + seconds).substr(-2));
+        clockStr = (days > 0 ? days + "d " : "") + clock.join(":");
+        remainStr = remain > 0 ? clockStr : "Expired.";
+        svgPath.append("text").attr("class", "clock").attr("x", width - ph_m)
+                .attr("y", ph_h).attr("text-anchor", "end").style("font-size",
+                        "14px").style("fill", color).text(remainStr);
+        if (remain > 0) {
+            expClock = setTimeout(function() {
+                drawTitle(title, color, expTime)
+            }, secondMs)
+        }
+    }
+}
+
+/*
+ * Clears title and countdown elements from path graph.
+ */
+function removeTitle() {
+    clearTimeout(expClock);
+    svgPath.selectAll(".title").remove();
+    svgPath.selectAll(".clock").remove();
 }

--- a/python/web/asviz/static/js/topology.js
+++ b/python/web/asviz/static/js/topology.js
@@ -140,6 +140,28 @@ function addNodeFromLink(graph, name, type, node) {
 }
 
 /*
+ * Modifies existing path topology with more accurate segments, but only when
+ * available.
+ */
+function updateGraphWithSegments(graph, segs, head) {
+    for (var i = 0; i < segs.length; i++) {
+        if (head) {
+            _if = segs[i].interfaces[0];
+        } else {
+            _if = segs[i].interfaces.slice(-1)[0];
+        }
+        core_ia = _if.ISD + "-" + _if.AS;
+        for (var j = 0; j < graph.nodes.length; j++) {
+            var name = graph.nodes[j].name;
+            if (name == core_ia) {
+                graph.nodes[j].group = ((ISD.exec(name) - 1) * 4);
+                graph.nodes[j].type = LinkType.Core;
+            }
+        }
+    }
+}
+
+/*
  * Converts links-only topology data into D3 graph layout.
  */
 function convertLinks2Graph(links_topo) {

--- a/python/web/asviz/templates/asviz/index.html
+++ b/python/web/asviz/templates/asviz/index.html
@@ -47,7 +47,7 @@
   <div id="info">
    <ul>
     <li><a href='http://scion-architecture.net'>SCION Website</a></li>
-    <li><a href='http://github.com/netsec-ethz/scion'>SCION</a> on
+    <li><a href='http://github.com/scionproto/scion'>SCION</a> on
      Github</li>
     <li><a href='http://github.com/netsec-ethz/scion-viz'>SCION
       Visualizations</a> on Github</li>
@@ -198,20 +198,26 @@
         jTopo = JSON.parse('{{ json_path_topo | safe }}');
         json_as_topo = JSON.parse('{{ json_as_topo | safe }}');
 
+        // ensure local hops data flows deterministically
+        orderPaths('{{ src }}', '{{ dst }}');
+
         // load path topology
         var width = $("#as-pathtopo").width();
         var height = $("#as-pathtopo").height();
-        drawTopology("as-pathtopo", jTopo, width, height);
+        drawTopology("as-pathtopo", jTopo, resSegs, width, height);
         // add endpoint labels
         topoSetup({
             "source" : '{{ src }}',
             "destination" : '{{ dst }}',
         }, width, height);
+        setupPathSelection();
+        setupListTree();
 
         // add AS topology layout
         var width = $("#as-astopo").width();
         var height = $("#as-astopo").height();
         drawAsTopo("as-astopo", json_as_topo, width, height);
+        document.getElementById("as-selection").innerHTML = "Click on a server";
     }
 </script>
 <noscript>This form requires that you have javascript enabled


### PR DESCRIPTION
- Uses new lib_sciond.get_segtype_hops().
- Depends on https://github.com/scionproto/scion/pull/1383.
- Closes #30.
- Adds ability to request detailed segment data after get_paths().
- Adds display of core/up/down segments in Paths tab.
- Requested segment data used to calculate core ASes in paths.
- Requested segment data used to calculate path types.
- Adding command-line segment summary '-s' option.
- Updates website links on visualization page.
- Adding path/segment selection title to paths graph.
- Adding segment expiration timer to paths graph.
- Reducing some info logging to debug level.
- Adding padding margin to path legend.
- Prevents color bleeding between path/segment selections.
- Closes #34, fixes missing legend labels.
- Eliminates extra peer link overlays in paths graph.
- Adds correct node core status for paths without core segments.
- Ensures path/segment selection remains after switching tabs.
- Reserves path/segment title header, preventing rendering over title.
- Formatting code for compactness.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-viz/40)
<!-- Reviewable:end -->
